### PR TITLE
Fix bug when the delta symbol is missing in some inputs

### DIFF
--- a/modules/languageL1.py
+++ b/modules/languageL1.py
@@ -38,7 +38,7 @@ def delta_helper(state, string):
     elif state == "q\u2081" and string[-1] == "1":
         ROW_SAVER.append("{q\u2082}")
     elif state == "q\u2082" and string[-1] == "0":
-        ROW_SAVER.append("{q\u2082}, {q\u2083}")
+        ROW_SAVER.append("{q\u2082, q\u2083}")
     elif state == "q\u2082" and string[-1] == "1":
         ROW_SAVER.append("{q\u2082}")
     elif state == "q\u2084" and string[-1] == "0":
@@ -76,6 +76,8 @@ def delta(state, string):
         TEMP.add("q\u2084")
     elif state == "q\u2084" and string[-1] == "1":
         TEMP.add("q\u2081")
+    else:
+        TEMP.add("\u2205")
 
 
 #
@@ -123,7 +125,12 @@ def delta_hat(state, string):
     SAVER = TEMP
     TEMP = set([])
     # append the result of the process to the global variable ROW_SAVER
-    ROW_SAVER.append("{" + ", ".join(list(SAVER)) + "}")
+    if len(SAVER) == 1 and list(SAVER)[0] == "\u2205":
+        ROW_SAVER.append(", ".join(list(SAVER)))
+    else:
+        if "\u2205" in SAVER:
+            SAVER.remove("\u2205")
+        ROW_SAVER.append("{" + ", ".join(list(SAVER)) + "}")
     # for every function call, the result will be appended to DETAIL_SAVER
     DETAIL_SAVER.append(" ".join(ROW_SAVER))
 


### PR DESCRIPTION
## Description

Fixes #10 

I have fixed bug in module for L1 language where the delta symbol `δ` is missing in some inputs, especially on inputs that start with symbol `0`. The image below shows the new detail process:

<img width="960" alt="fix-language-l1-bug" src="https://user-images.githubusercontent.com/90038606/194718898-2bcac990-b3f5-42fa-aae6-bca15d1a3e5c.png">

## Type of change

- [x] Bug fix

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have commented my code, particularly in hard-to-understand areas
